### PR TITLE
Add HalosGateBananaPhoneMode mode and getSysIDFromNeighbor function

### DIFF
--- a/pkg/BananaPhone/bananaphone.go
+++ b/pkg/BananaPhone/bananaphone.go
@@ -20,13 +20,16 @@ const (
 	DiskBananaPhoneMode
 	//AutoBananaPhoneMode will resolve by first trying to resolve in-memory, and then falling back to loading from disk if in-memory fails (eg, if it's hooked and the sysid's have been moved).
 	AutoBananaPhoneMode
+	//HalosGateBananaPhoneMode will resolve by first trying to resolve in-memory, and then falling back to deduce the syscall by searching a non-hooked function
+	HalosGateBananaPhoneMode
 )
 
 //BananaPhone will resolve SysID's used for syscalls while making minimal API calls. These ID's can be used for functions like NtAllocateVirtualMemory as defined in functions.go.
 type BananaPhone struct {
-	banana *pe.File
-	isAuto bool
-	memloc uintptr
+	banana      *pe.File
+	isAuto      bool
+	isHalosGate bool
+	memloc      uintptr
 }
 
 //NewBananaPhone creates a new instance of a bananaphone with behaviour as defined by the input value. Use AutoBananaPhoneMode if you're not sure.
@@ -35,6 +38,7 @@ Possible values:
 	- MemoryBananaPhoneMode
 	- DiskBananaPhoneMode
 	- AutoBananaPhoneMode
+	- HalosGate
 */
 func NewBananaPhone(t PhoneMode) (*BananaPhone, error) {
 	return NewBananaPhoneNamed(t, "ntdll.dll", `C:\Windows\system32\ntdll.dll`)
@@ -52,12 +56,15 @@ Possible values:
 	- MemoryBananaPhoneMode
 	- DiskBananaPhoneMode
 	- AutoBananaPhoneMode
+	- HalosGate
 */
 func NewBananaPhoneNamed(t PhoneMode, name, diskpath string) (*BananaPhone, error) {
 	var p *pe.File
 	var e error
 	var bp = &BananaPhone{}
 	switch t {
+	case HalosGateBananaPhoneMode:
+		fallthrough
 	case AutoBananaPhoneMode:
 		fallthrough
 	case MemoryBananaPhoneMode:
@@ -83,6 +90,7 @@ func NewBananaPhoneNamed(t PhoneMode, name, diskpath string) (*BananaPhone, erro
 	}
 	bp.banana = p
 	bp.isAuto = t == AutoBananaPhoneMode
+	bp.isHalosGate = t == HalosGateBananaPhoneMode
 	return bp, e
 }
 
@@ -128,6 +136,8 @@ func (b *BananaPhone) GetSysID(funcname string) (uint16, error) {
 				return 0, e2
 			}
 			r, e = b.getSysID(funcname, 0, false)
+		} else if b.isHalosGate && errors.As(e, &err) {
+			r, e = b.getSysIDFromNeighbor(funcname, 0, false)
 		}
 	}
 	return r, e
@@ -168,6 +178,62 @@ func (b BananaPhone) getSysID(funcname string, ord uint32, useOrd bool) (uint16,
 			buff := b[offset : offset+10]
 
 			return sysIDFromRawBytes(buff)
+		}
+	}
+	return 0, errors.New("Could not find syscall ID")
+}
+
+//getSysIDFromNeighboor deduces the syscall ID based on the a neighbor's syscall that is not hooked
+func (b BananaPhone) getSysIDFromNeighbor(funcname string, ord uint32, useOrd bool) (uint16, error) {
+
+	ex, e := b.banana.Exports()
+	if e != nil {
+		return 0, e
+	}
+
+	for _, exp := range ex {
+		if (useOrd && exp.Ordinal == ord) || // many bothans died for this feature (thanks awgh). Turns out that a value can be exported by ordinal, but not by name! man I love PE files. ha ha jk.
+			exp.Name == funcname {
+			offset := rvaToOffset(b.banana, exp.VirtualAddress)
+			bBytes, e := b.banana.Bytes()
+			if e != nil {
+				return 0, e
+			}
+			buff := bBytes[offset : offset+10]
+
+			sysId, e := sysIDFromRawBytes(buff)
+			var err MayBeHookedError
+			// Look for the syscall ID in the neighborhood
+			if errors.As(e, &err) {
+				start, size := GetNtdllStart()
+				distanceNeighbor := 0
+				// Search forward
+				for i := uintptr(offset); i < start+size; i += 1 {
+					if bBytes[i] == byte('\x0f') && bBytes[i+1] == byte('\x05') && bBytes[i+2] == byte('\xc3') {
+						distanceNeighbor++
+						// The sysid should be located 14 bytes after the syscall; ret instruction.
+						sysId, e := sysIDFromRawBytes(bBytes[i+14 : i+14+8])
+						if !errors.As(e, &err) {
+							return sysId - uint16(distanceNeighbor), e
+						}
+					}
+				}
+				// reset the value to 1. When we go forward we catch the current syscall; ret but not when we go backward, so distanceNeighboor = 0 for forward and distanceNeighboor = 1 for backward
+				distanceNeighbor = 1
+				// If nothing has been found forward, search backward
+				for i := uintptr(offset) - 1; i > 0; i -= 1 {
+					if bBytes[i] == byte('\x0f') && bBytes[i+1] == byte('\x05') && bBytes[i+2] == byte('\xc3') {
+						distanceNeighbor++
+						// The sysid should be located 14 bytes after the syscall; ret instruction.
+						sysId, e := sysIDFromRawBytes(bBytes[i+14 : i+14+8])
+						if !errors.As(e, &err) {
+							return sysId + uint16(distanceNeighbor) - 1, e
+						}
+					}
+				}
+			} else {
+				return sysId, e
+			}
 		}
 	}
 	return 0, errors.New("Could not find syscall ID")


### PR DESCRIPTION
Support for Halo's Gate method.
If `HalosGateBananaPhoneMode` is configured and the function is detected as being hooked, the function `getSysIDFromNeighbor` will be called to look for the next function that is not hooked and retrieve the syscall id to deduce the syscall id of the hooked function (if no function is found, it will search backwards). Therefore, this mode avoids opening the ntdll.dll file.